### PR TITLE
faucet: verify dcrlnd network

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -10,6 +10,9 @@
   
   <div class="row d-flex justify-content-center">
     <h1 id="title" class="flow-text">Lightning Network Faucet</h1>
+    {{ if .Network }}
+    <h6>{{ .Network }}</h6>
+    {{end}}
   </div>
 
   <div class="row justify-content-center pt-4">


### PR DESCRIPTION
Verify dcrlnd network and comparing to the network set in dcrlnfaucet.

If this is in a different network, stop the lnrpc client creation.

Fixes #15 