### PR TITLE
multi: prune context usage and update link

### DIFF
--- a/faucet.go
+++ b/faucet.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/hex"
 	"fmt"
 	"html/template"
@@ -236,7 +235,7 @@ func cleanAndExpandPath(path string) string {
 // getChainInfo makes a request to get information about dcrlnd chain.
 func getChainInfo(l lnrpc.LightningClient) (*lnrpc.Chain, error) {
 	infoReq := &lnrpc.GetInfoRequest{}
-	info, err := l.GetInfo(context.Background(), infoReq)
+	info, err := l.GetInfo(ctxb, infoReq)
 	if err != nil {
 		return nil, fmt.Errorf("error on get information from node")
 	}
@@ -961,7 +960,6 @@ func (l *lightningFaucet) payInvoice(homeTemplate *template.Template,
 	lastPayInvoiceTime = time.Now()
 
 	// Get the invoice and try to verify and decode.
-	ctxb := context.Background()
 	rawPayReq := r.FormValue("payinvoice")
 	payReq := strings.TrimSpace(rawPayReq)
 	payReqString := &lnrpc.PayReqString{PayReq: payReq}

--- a/static/footer.html
+++ b/static/footer.html
@@ -18,7 +18,7 @@
           <div class="col-md-4 col-12 footer__credit-column h-100">
             <div class="d-flex justify-content-center h-100">
               <div class="align-self-center">
-                <p class="mb-0">Decred developers | 2019<br>The source code is available on <a href="https://github.com/matheusd/lightning-faucet">GitHub</a>
+                <p class="mb-0">Decred developers | 2019<br>The source code is available on <a href="https://github.com/decred/lightning-faucet">GitHub</a>
                 </p>
               </div>
             </div>

--- a/static/index.html
+++ b/static/index.html
@@ -149,7 +149,7 @@
 
         <input class="form-control {{if eq .SubmissionError 3 10 11 12 }}is-invalid{{end}}"
         {{if .FormFields }}value="{{.FormFields.Amt}}"{{end}}
-        id="amt" name="amt" type="number" required="true" value="0.01" max="0.2" step="0.0001">
+        id="amt" name="amt" type="number" required="true" value="0.01" max="0.2" step="0.000001">
 
         {{ if eq .SubmissionError 3 10 11 12 }}
           <div class="invalid-feedback">{{printf "%v" .SubmissionError}}</div>
@@ -193,6 +193,9 @@
   <form id="payInvoiceForm" method="post" action="/?action={{ .PayInvoiceAction }}">
       <div class="form-group">
 
+        <label for="node">
+		PayReq (maximum amount is <b>0.00001</b>)
+        </label>
         <input class="form-control {{if eq .SubmissionError 12 14 15 16 }}is-invalid{{end}}"
         id="payinvoice" name="payinvoice" type="text" required="true" placeholder="Invoce code">
         


### PR DESCRIPTION
Remove the import of context package from faucet.go
and use just the global var ctxb.

Update the footer link.

Update the steps in generate invoice form for user can
create small invoices amount to use in pay invoice form.