### PR TITLE
Remove quotes from generic font-family names

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,13 +9,13 @@ jobs:
         go: [1.13, 1.14]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
       - name: Check out source
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0"
+        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0"
       - name: Build
         env:
           GO111MODULE: "on"

--- a/static/css/fonts.css
+++ b/static/css/fonts.css
@@ -48,11 +48,9 @@
 }
 
 html, body {
-    /* use !important to prevent issues with browser extensions that change fonts */
-    font-family: "dcrlnfaucet", "Verdana", "sans-serif" !important;
+    font-family: "dcrlnfaucet", "Verdana", sans-serif;
 }
 
 pre, code {
-    /* use !important to prevent issues with browser extensions that change fonts */
-    font-family: "dcrlnfaucet-code", "Courier New", "monospace" !important;
+    font-family: "dcrlnfaucet-code", "Courier New", monospace;
 }

--- a/static/header.html
+++ b/static/header.html
@@ -6,8 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 
     <link type="text/css" rel="stylesheet" href="/static/css/lib/bootstrap.4.3.1.min.css">
-    <link type="text/css" rel="stylesheet" href="/static/css/fonts.css">
     <link type="text/css" rel="stylesheet" href="/static/css/lightning.css">
+    <!-- fonts.css should be last to ensure dcr fonts take precedence. -->
+    <link type="text/css" rel="stylesheet" href="/static/css/fonts.css">
 
     <script type="text/javascript" src="/static/js/lib/jquery-2.1.1.min.js"></script>
     <script type="text/javascript" src="/static/js/lib/bootstrap.4.3.1.min.js"></script>


### PR DESCRIPTION
Discovered in decred/dcrdocs#1103, generic font-family names should not have quotes: https://developer.mozilla.org/en-US/docs/Web/CSS/font-family

Also taken the opportunity to update build deps.